### PR TITLE
Add skips for tests requiring 'seasonal'

### DIFF
--- a/tests/testthat/test-features.R
+++ b/tests/testthat/test-features.R
@@ -15,6 +15,7 @@ test_that("guerrero()", {
 })
 
 test_that("unit root features", {
+  skip_if_not_installed("seasonal")
   ft <- features(www_usage, value, list(unitroot_kpss, unitroot_pp, unitroot_ndiffs))
   expect_equal(ft$kpss_pvalue < 0.05, as.logical(ft$ndiffs))
   expect_equal(ft$pp_pvalue, 0.1)
@@ -62,6 +63,7 @@ test_that("*shift features", {
 })
 
 test_that("model based features", {
+  skip_if_not_installed("seasonal")
   model_features <- list(stat_arch_lm, coef_hurst, feat_stl)
   ft <- features(www_usage, value, model_features)
   expect_equivalent(


### PR DESCRIPTION
Now, these tests fail opaquely:

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-features.R:20:3): unit root features ──────────────────────────
ft$pp_pvalue not equal to 0.1.
target is NULL, current is numeric
── Failure (test-features.R:67:3): model based features ────────────────────────
as.list(ft) not equivalent to list(...).
Length mismatch: comparison on first 7 components
Component 2: Mean relative difference: 0.01292009
Component 3: Mean relative difference: 11.76622
Component 4: Mean relative difference: 0.9995659
Component 5: Mean relative difference: 3.041742
Component 6: Mean relative difference: 55.83438
Component 7: Mean relative difference: 0.2125561
```